### PR TITLE
Use Switch widget on API 21+

### DIFF
--- a/preference-v7/src/main/res/layout-v21/preference_widget_switch_compat.xml
+++ b/preference-v7/src/main/res/layout-v21/preference_widget_switch_compat.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+
+<!-- Layout used by SwitchPreference for the switch widget style. This is inflated
+     inside android.R.layout.preference. -->
+<Switch xmlns:android="http://schemas.android.com/apk/res/android"
+                                        android:id="@+id/switchWidget"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:focusable="false"
+                                        android:clickable="false"
+                                        android:background="@null" />


### PR DESCRIPTION
SwitchCompat used in SwitchPreferenceCompat isn’t animated on API 21+ (due to this bug: https://code.google.com/p/android/issues/detail?id=196652), we can replace it with native Switch widget on API 21+ to fix that.